### PR TITLE
Add scrollable rule editor with multi-keyword support

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -11,7 +11,7 @@ loader_version=0.14.21
 loom_version=1.6-SNAPSHOT
 
 # Mod Properties
-mod_version=1.0.0
+mod_version=1.1.0
 maven_group=com.example
 archives_base_name=Item Lore Highlighter
 

--- a/src/client/java/cn/coatcn/bookhighlight/BookHighlightConfigScreen.java
+++ b/src/client/java/cn/coatcn/bookhighlight/BookHighlightConfigScreen.java
@@ -7,25 +7,36 @@ import net.minecraft.client.gui.widget.ButtonWidget;
 import net.minecraft.client.gui.widget.TextFieldWidget;
 import net.minecraft.text.Text;
 import net.minecraft.util.Formatting;
+import net.minecraft.util.math.MathHelper;
 
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
+import java.util.Iterator;
 import java.util.List;
-import java.util.Map;
 
 /**
- * 简易设置界面：
- * - 显示并可编辑当前选中的中文关键字
- * - 可新增/删除条目
+ * 设置界面：
+ * - 支持为每条规则添加多个关键字（全部匹配时命中）
+ * - 可新增/删除规则，并单独控制显示开关
+ * - 列表支持滚动浏览
  */
 public class BookHighlightConfigScreen extends Screen {
 
-    private final List<TextFieldWidget> fields = new ArrayList<>();
-    private final List<ButtonWidget> removeButtons = new ArrayList<>();
-    private final List<ButtonWidget> toggleButtons = new ArrayList<>();
-    private final List<Boolean> visibleFlags = new ArrayList<>();
+    private static final int TOP_PADDING = 40;
+    private static final int BOTTOM_PADDING = 80;
+    private static final int ROW_HEIGHT = 24;
+    private static final int ENTRY_SPACING = 6;
+    private static final int KEYWORD_WIDTH = 160;
+    private static final int SUB_INDENT = 16;
+    private static final int BUTTON_SIZE = 20;
+    private static final int TOGGLE_WIDTH = 60;
+    private static final int BUTTON_GAP = 4;
+    private static final int BUTTON_START_GAP = 8;
+
+    private final List<Entry> entries = new ArrayList<>();
     private ButtonWidget addButton;
     private ButtonWidget doneButton;
+    private double scrollOffset;
+    private int contentHeight;
 
     public BookHighlightConfigScreen() {
         super(Text.literal("高亮关键字配置"));
@@ -34,83 +45,54 @@ public class BookHighlightConfigScreen extends Screen {
     @Override
     protected void init() {
         super.init();
-        ConfigManager.getInstance().reloadIfChanged();
-        fields.clear();
-        removeButtons.clear();
-        toggleButtons.clear();
-        visibleFlags.clear();
+        clearChildren();
+        entries.clear();
+        scrollOffset = 0;
 
-        int y = 40;
-        for (var entry : ConfigManager.getInstance().getTargetMap().entrySet()) {
-            addEntry(entry.getKey(), entry.getValue(), y);
-            y += 24;
+        ConfigManager.getInstance().reloadIfChanged();
+
+        List<TargetRule> stored = ConfigManager.getInstance().getTargets();
+        if (stored.isEmpty()) {
+            addEntry(List.of(""), true);
+        } else {
+            for (TargetRule rule : stored) {
+                addEntry(rule.getKeywords(), rule.isVisible());
+            }
         }
 
-        addButton = ButtonWidget.builder(Text.literal("Add"), btn -> addEntry("", true, 40 + fields.size() * 24))
-                .dimensions(width / 2 - 100, height - 60, 60, 20)
+        addButton = ButtonWidget.builder(Text.literal("新增规则"), btn -> addEntry(List.of(""), true))
+                .dimensions(0, 0, 90, 20)
                 .build();
         addDrawableChild(addButton);
 
-        doneButton = ButtonWidget.builder(Text.literal("Done"), btn -> saveAndClose())
-                .dimensions(width / 2 - 40, height - 30, 80, 20)
+        doneButton = ButtonWidget.builder(Text.literal("完成"), btn -> saveAndClose())
+                .dimensions(0, 0, 90, 20)
                 .build();
         addDrawableChild(doneButton);
+
+        layoutFooterButtons();
+        updateLayout();
     }
 
-    private void addEntry(String text, boolean visible, int y) {
-        int fieldX = width / 2 - 100;
-        TextFieldWidget field = new TextFieldWidget(textRenderer, fieldX, y, 120, 20, Text.literal("name"));
-        field.setMaxLength(64);
-        field.setText(text);
-        fields.add(field);
-        visibleFlags.add(visible);
-        addDrawableChild(field);
-
-        ButtonWidget toggle = ButtonWidget.builder(getToggleText(visible), btn -> {
-            int idx = toggleButtons.indexOf(btn);
-            boolean nv = !visibleFlags.get(idx);
-            visibleFlags.set(idx, nv);
-            btn.setMessage(getToggleText(nv));
-        }).dimensions(fieldX + 125, y, 20, 20).build();
-        toggleButtons.add(toggle);
-        addDrawableChild(toggle);
-
-        ButtonWidget remove = ButtonWidget.builder(Text.literal("X"), btn -> {
-            int idx = fields.indexOf(field);
-            if (idx >= 0) {
-                remove(field);
-                remove(removeButtons.get(idx));
-                remove(toggleButtons.get(idx));
-                fields.remove(idx);
-                removeButtons.remove(idx);
-                toggleButtons.remove(idx);
-                visibleFlags.remove(idx);
-                relayoutEntries();
-            }
-        }).dimensions(fieldX + 150, y, 20, 20).build();
-        removeButtons.add(remove);
-        addDrawableChild(remove);
-    }
-
-    private void relayoutEntries() {
-        for (int i = 0; i < fields.size(); i++) {
-            int y = 40 + i * 24;
-            fields.get(i).setY(y);
-            toggleButtons.get(i).setY(y);
-            removeButtons.get(i).setY(y);
-        }
-    }
-
-    private void saveAndClose() {
-        Map<String, Boolean> map = new LinkedHashMap<>();
-        for (int i = 0; i < fields.size(); i++) {
-            String s = fields.get(i).getText().trim();
-            if (!s.isEmpty()) {
-                map.put(s, visibleFlags.get(i));
+    @Override
+    public void tick() {
+        for (Entry entry : entries) {
+            for (KeywordRow row : entry.rows) {
+                row.field.tick();
             }
         }
-        ConfigManager.getInstance().updateTargets(map);
-        MinecraftClient.getInstance().setScreen(null);
+    }
+
+    @Override
+    public boolean mouseScrolled(double mouseX, double mouseY, double amount) {
+        int areaHeight = Math.max(0, height - TOP_PADDING - BOTTOM_PADDING);
+        if (contentHeight <= areaHeight || areaHeight <= 0) {
+            return super.mouseScrolled(mouseX, mouseY, amount);
+        }
+        double maxScroll = contentHeight - areaHeight;
+        scrollOffset = MathHelper.clamp(scrollOffset - amount * 20, 0, maxScroll);
+        updateLayout();
+        return true;
     }
 
     @Override
@@ -118,6 +100,7 @@ public class BookHighlightConfigScreen extends Screen {
         renderBackground(context);
         super.render(context, mouseX, mouseY, delta);
         context.drawCenteredTextWithShadow(textRenderer, title, width / 2, 15, 0xFFFFFF);
+        drawScrollbar(context);
     }
 
     @Override
@@ -125,8 +108,220 @@ public class BookHighlightConfigScreen extends Screen {
         return false;
     }
 
+    private void addEntry(List<String> keywords, boolean visible) {
+        Entry entry = new Entry(keywords, visible);
+        entries.add(entry);
+        updateLayout();
+    }
+
+    private void removeEntry(Entry entry) {
+        for (KeywordRow row : entry.rows) {
+            remove(row.field);
+            if (row.removeButton != null) {
+                remove(row.removeButton);
+            }
+        }
+        remove(entry.addKeywordButton);
+        remove(entry.toggleButton);
+        remove(entry.removeEntryButton);
+        entries.remove(entry);
+        updateLayout();
+    }
+
+    private void addKeywordRow(Entry entry, String value, boolean primary) {
+        TextFieldWidget field = new TextFieldWidget(textRenderer, 0, 0, KEYWORD_WIDTH, 20, Text.literal("keyword"));
+        field.setMaxLength(64);
+        field.setText(value == null ? "" : value);
+        addDrawableChild(field);
+
+        ButtonWidget removeButton = null;
+        if (!primary) {
+            removeButton = ButtonWidget.builder(Text.literal("-"), btn -> removeKeywordRow(entry, field))
+                    .dimensions(0, 0, BUTTON_SIZE, 20)
+                    .build();
+            addDrawableChild(removeButton);
+        }
+
+        entry.rows.add(new KeywordRow(field, removeButton));
+    }
+
+    private void removeKeywordRow(Entry entry, TextFieldWidget field) {
+        Iterator<KeywordRow> iterator = entry.rows.iterator();
+        while (iterator.hasNext()) {
+            KeywordRow row = iterator.next();
+            if (row.field == field) {
+                remove(row.field);
+                if (row.removeButton != null) {
+                    remove(row.removeButton);
+                }
+                iterator.remove();
+                break;
+            }
+        }
+        if (entry.rows.isEmpty()) {
+            addKeywordRow(entry, "", true);
+        }
+        updateLayout();
+    }
+
+    private void updateLayout() {
+        recalcContentHeight();
+        clampScroll();
+        int totalWidth = KEYWORD_WIDTH + BUTTON_START_GAP + BUTTON_SIZE + BUTTON_GAP + TOGGLE_WIDTH + BUTTON_GAP + BUTTON_SIZE;
+        int fieldX = width / 2 - totalWidth / 2;
+        int buttonStartX = fieldX + KEYWORD_WIDTH + BUTTON_START_GAP;
+        int y = TOP_PADDING - (int) Math.round(scrollOffset);
+
+        for (Entry entry : entries) {
+            if (entry.rows.isEmpty()) {
+                addKeywordRow(entry, "", true);
+            }
+            KeywordRow mainRow = entry.rows.get(0);
+            configureField(mainRow.field, fieldX, y, KEYWORD_WIDTH);
+
+            entry.addKeywordButton.setX(buttonStartX);
+            entry.addKeywordButton.setY(y);
+            entry.toggleButton.setX(buttonStartX + BUTTON_SIZE + BUTTON_GAP);
+            entry.toggleButton.setY(y);
+            entry.removeEntryButton.setX(buttonStartX + BUTTON_SIZE + BUTTON_GAP + TOGGLE_WIDTH + BUTTON_GAP);
+            entry.removeEntryButton.setY(y);
+
+            y += ROW_HEIGHT;
+
+            for (int i = 1; i < entry.rows.size(); i++) {
+                KeywordRow row = entry.rows.get(i);
+                configureField(row.field, fieldX + SUB_INDENT, y, KEYWORD_WIDTH - SUB_INDENT);
+                if (row.removeButton != null) {
+                    row.removeButton.setX(buttonStartX);
+                    row.removeButton.setY(y);
+                }
+                y += ROW_HEIGHT;
+            }
+
+            y += ENTRY_SPACING;
+        }
+
+        layoutFooterButtons();
+    }
+
+    private void recalcContentHeight() {
+        int total = 0;
+        for (Entry entry : entries) {
+            int rows = Math.max(1, entry.rows.size());
+            total += rows * ROW_HEIGHT;
+            total += ENTRY_SPACING;
+        }
+        if (total > 0) {
+            total -= ENTRY_SPACING;
+        }
+        contentHeight = total;
+    }
+
+    private void clampScroll() {
+        int areaHeight = Math.max(0, height - TOP_PADDING - BOTTOM_PADDING);
+        if (areaHeight <= 0) {
+            scrollOffset = 0;
+            return;
+        }
+        double maxScroll = Math.max(0, contentHeight - areaHeight);
+        scrollOffset = MathHelper.clamp(scrollOffset, 0, maxScroll);
+    }
+
+    private void layoutFooterButtons() {
+        int footerY = height - 45;
+        if (addButton != null) {
+            addButton.setX(width / 2 - 120);
+            addButton.setY(footerY);
+        }
+        if (doneButton != null) {
+            doneButton.setX(width / 2 + 30);
+            doneButton.setY(footerY);
+        }
+    }
+
+    private void configureField(TextFieldWidget field, int x, int y, int width) {
+        field.setX(x);
+        field.setY(y);
+        field.setWidth(width);
+    }
+
+    private void drawScrollbar(DrawContext context) {
+        int areaHeight = Math.max(0, height - TOP_PADDING - BOTTOM_PADDING);
+        if (contentHeight <= areaHeight || areaHeight <= 0) {
+            return;
+        }
+        int trackX = width - 12;
+        int trackWidth = 6;
+        int trackY = TOP_PADDING;
+        context.fill(trackX, trackY, trackX + trackWidth, trackY + areaHeight, 0x33000000);
+
+        int knobHeight = Math.max(20, (int) ((float) areaHeight * areaHeight / contentHeight));
+        int maxScroll = contentHeight - areaHeight;
+        int knobY = trackY + (int) ((areaHeight - knobHeight) * (scrollOffset / maxScroll));
+        context.fill(trackX, knobY, trackX + trackWidth, knobY + knobHeight, 0x99FFFFFF);
+    }
+
+    private void saveAndClose() {
+        List<TargetRule> rules = new ArrayList<>();
+        for (Entry entry : entries) {
+            List<String> keywords = new ArrayList<>();
+            for (KeywordRow row : entry.rows) {
+                String text = row.field.getText().trim();
+                if (!text.isEmpty()) {
+                    keywords.add(text);
+                }
+            }
+            if (!keywords.isEmpty()) {
+                rules.add(new TargetRule(keywords, entry.visible));
+            }
+        }
+        ConfigManager.getInstance().updateTargets(rules);
+        MinecraftClient.getInstance().setScreen(null);
+    }
+
     private Text getToggleText(boolean visible) {
         return Text.literal(visible ? "显示" : "隐藏")
                 .formatted(visible ? Formatting.GREEN : Formatting.RED);
+    }
+
+    private final class Entry {
+        final List<KeywordRow> rows = new ArrayList<>();
+        boolean visible;
+        final ButtonWidget addKeywordButton;
+        final ButtonWidget toggleButton;
+        final ButtonWidget removeEntryButton;
+
+        Entry(List<String> keywords, boolean visible) {
+            this.visible = visible;
+            this.addKeywordButton = ButtonWidget.builder(Text.literal("+"), btn -> {
+                        addKeywordRow(this, "", false);
+                        updateLayout();
+                    })
+                    .dimensions(0, 0, BUTTON_SIZE, 20)
+                    .build();
+            this.toggleButton = ButtonWidget.builder(getToggleText(this.visible), btn -> {
+                        this.visible = !this.visible;
+                        btn.setMessage(getToggleText(this.visible));
+                    })
+                    .dimensions(0, 0, TOGGLE_WIDTH, 20)
+                    .build();
+            this.removeEntryButton = ButtonWidget.builder(Text.literal("X"), btn -> removeEntry(this))
+                    .dimensions(0, 0, BUTTON_SIZE, 20)
+                    .build();
+
+            addDrawableChild(addKeywordButton);
+            addDrawableChild(toggleButton);
+            addDrawableChild(removeEntryButton);
+
+            List<String> initial = keywords == null || keywords.isEmpty() ? List.of("") : keywords;
+            boolean first = true;
+            for (String keyword : initial) {
+                addKeywordRow(this, keyword, first);
+                first = false;
+            }
+        }
+    }
+
+    private record KeywordRow(TextFieldWidget field, ButtonWidget removeButton) {
     }
 }

--- a/src/client/java/cn/coatcn/bookhighlight/mixin/HandledScreenMixin.java
+++ b/src/client/java/cn/coatcn/bookhighlight/mixin/HandledScreenMixin.java
@@ -7,6 +7,7 @@ import net.minecraft.client.gui.screen.ingame.HandledScreen;
 import net.minecraft.inventory.Inventory;
 import net.minecraft.item.ItemStack;
 import net.minecraft.screen.GenericContainerScreenHandler;
+import net.minecraft.screen.HopperScreenHandler;
 import net.minecraft.screen.PlayerScreenHandler;
 import net.minecraft.screen.ScreenHandler;
 import net.minecraft.screen.ShulkerBoxScreenHandler;
@@ -25,7 +26,9 @@ public abstract class HandledScreenMixin {
 
     private static boolean book_highlight$isSupportedContainer(ScreenHandler handler) {
         if (handler == null) return false;
-        return handler instanceof GenericContainerScreenHandler || handler instanceof ShulkerBoxScreenHandler;
+        return handler instanceof GenericContainerScreenHandler
+                || handler instanceof ShulkerBoxScreenHandler
+                || handler instanceof HopperScreenHandler;
     }
 
     // 关键：method 指向 intermediary 名 + 描述符；remap=false
@@ -43,7 +46,7 @@ public abstract class HandledScreenMixin {
         ItemStack stack = slot.getStack();
         if (stack == null || stack.isEmpty()) return;
 
-        var targets = ConfigManager.getInstance().getVisibleNamesCn();
+        var targets = ConfigManager.getInstance().getVisibleTargets();
         if (EnchantMatch.shouldHighlightItem(stack, targets)) {
             int color = ConfigManager.getInstance().getHighlightColor(); // ARGB
             // context 在 drawSlot 之前已平移到容器原点，这里无需再次加 x/y

--- a/src/main/java/cn/coatcn/bookhighlight/EnchantMatch.java
+++ b/src/main/java/cn/coatcn/bookhighlight/EnchantMatch.java
@@ -7,13 +7,14 @@ import net.minecraft.nbt.NbtList;
 import net.minecraft.text.Text;
 import net.minecraft.text.Text.Serializer;
 
-import java.util.Set;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * 匹配逻辑：
  * 1）不再限制物品类型，任意物品都可参与判断；
  * 2）读取物品的 display.NBT（自定义名称、Lore 等），判断是否包含配置的中文关键字；
- * 3）若名称或任意描述行命中关键字，则需要高亮。
+ * 3）若名称或描述文本同时包含某条规则的全部关键字，则需要高亮。
  */
 public class EnchantMatch {
 
@@ -22,28 +23,49 @@ public class EnchantMatch {
     /**
      * 判断该物品栈是否需要被高亮显示。
      */
-    public static boolean shouldHighlightItem(ItemStack stack, Set<String> targetKeywords) {
+    public static boolean shouldHighlightItem(ItemStack stack, List<TargetRule> targetRules) {
         if (stack == null || stack.isEmpty()) {
             return false;
         }
-        if (targetKeywords == null || targetKeywords.isEmpty()) {
+        if (targetRules == null || targetRules.isEmpty()) {
             return false;
         }
 
-        // 先检查物品名称（包括自定义名称）
-        if (containsKeyword(stack.getName().getString(), targetKeywords)) {
-            return true;
+        List<String> texts = collectTexts(stack);
+        if (texts.isEmpty()) {
+            return false;
         }
 
-        // 读取 Lore 描述行
+        for (TargetRule rule : targetRules) {
+            if (rule == null) continue;
+            List<String> keywords = rule.getKeywords();
+            if (keywords == null || keywords.isEmpty()) continue;
+            if (matchesAllKeywords(texts, keywords)) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
+    private static List<String> collectTexts(ItemStack stack) {
+        List<String> texts = new ArrayList<>();
+        String name = stack.getName().getString();
+        if (name != null && !name.isBlank()) {
+            texts.add(name);
+        }
+
         NbtCompound nbt = stack.getNbt();
         if (nbt != null && nbt.contains("display", NbtElement.COMPOUND_TYPE)) {
             NbtCompound display = nbt.getCompound("display");
             if (display.contains("Name", NbtElement.STRING_TYPE)) {
                 try {
-                    Text name = Serializer.fromJson(display.getString("Name"));
-                    if (name != null && containsKeyword(name.getString(), targetKeywords)) {
-                        return true;
+                    Text customName = Serializer.fromJson(display.getString("Name"));
+                    if (customName != null) {
+                        String s = customName.getString();
+                        if (s != null && !s.isBlank()) {
+                            texts.add(s);
+                        }
                     }
                 } catch (Exception ignored) {
                 }
@@ -54,8 +76,11 @@ public class EnchantMatch {
                     String json = lore.getString(i);
                     try {
                         Text line = Serializer.fromJson(json);
-                        if (line != null && containsKeyword(line.getString(), targetKeywords)) {
-                            return true;
+                        if (line != null) {
+                            String s = line.getString();
+                            if (s != null && !s.isBlank()) {
+                                texts.add(s);
+                            }
                         }
                     } catch (Exception ignored) {
                     }
@@ -63,15 +88,27 @@ public class EnchantMatch {
             }
         }
 
-        return false;
+        return texts;
     }
 
-    private static boolean containsKeyword(String text, Set<String> targetKeywords) {
-        if (text == null || text.isBlank()) {
+    private static boolean matchesAllKeywords(List<String> texts, List<String> keywords) {
+        if (keywords.isEmpty()) {
             return false;
         }
-        for (String keyword : targetKeywords) {
-            if (keyword != null && !keyword.isBlank() && text.contains(keyword)) {
+        for (String keyword : keywords) {
+            if (keyword == null || keyword.isBlank()) {
+                return false;
+            }
+            if (!containsKeyword(texts, keyword)) {
+                return false;
+            }
+        }
+        return true;
+    }
+
+    private static boolean containsKeyword(List<String> texts, String keyword) {
+        for (String text : texts) {
+            if (text != null && !text.isBlank() && text.contains(keyword)) {
                 return true;
             }
         }

--- a/src/main/java/cn/coatcn/bookhighlight/TargetRule.java
+++ b/src/main/java/cn/coatcn/bookhighlight/TargetRule.java
@@ -1,0 +1,47 @@
+package cn.coatcn.bookhighlight;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * 单条高亮规则，包含一组关键字（全部匹配时命中）以及可见开关。
+ */
+public class TargetRule {
+
+    private final List<String> keywords;
+    private final boolean visible;
+
+    public TargetRule(List<String> keywords, boolean visible) {
+        this.keywords = sanitizeKeywords(keywords);
+        this.visible = visible;
+    }
+
+    private static List<String> sanitizeKeywords(List<String> keywords) {
+        if (keywords == null || keywords.isEmpty()) {
+            return List.of();
+        }
+        List<String> list = new ArrayList<>();
+        for (String keyword : keywords) {
+            if (keyword == null) continue;
+            String trimmed = keyword.trim();
+            if (!trimmed.isEmpty()) {
+                list.add(trimmed);
+            }
+        }
+        return Collections.unmodifiableList(list);
+    }
+
+    public List<String> getKeywords() {
+        return keywords;
+    }
+
+    public boolean isVisible() {
+        return visible;
+    }
+
+    public TargetRule copy() {
+        return new TargetRule(new ArrayList<>(keywords), visible);
+    }
+}
+

--- a/src/main/resources/book_highlight/targets_cn.json
+++ b/src/main/resources/book_highlight/targets_cn.json
@@ -2,8 +2,8 @@
   "openKey": 66,
   "highlightColor": "0x80FFD700",
   "targets": [
-    { "name": "赋予效果", "visible": true },
-    { "name": "传说", "visible": true },
-    { "name": "史诗", "visible": true }
+    { "keywords": ["赋予效果"], "visible": true },
+    { "keywords": ["传说"], "visible": true },
+    { "keywords": ["史诗"], "visible": true }
   ]
 }


### PR DESCRIPTION
## Summary
- redesign the keyword configuration screen with a scrollable layout, per-rule sub-keyword fields, and rule management controls
- store configuration as multi-keyword rules and require all keywords to match before highlighting, including new TargetRule model updates
- enable highlighting in hopper screens and refresh default config along with a version bump

## Testing
- ./gradlew build --console=plain

------
https://chatgpt.com/codex/tasks/task_e_68ceeace12fc83318a9d757bce292ea4